### PR TITLE
Ensured contact phone number won't be stored in the clear

### DIFF
--- a/KinWallet.xcodeproj/project.pbxproj
+++ b/KinWallet.xcodeproj/project.pbxproj
@@ -642,6 +642,7 @@
 		03A2ABBBFE591E3F4BD322DF /* Pods-KinWalletTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KinWalletTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-KinWalletTests/Pods-KinWalletTests.debug.xcconfig"; sourceTree = "<group>"; };
 		14B2F22DB0CB4EBF944E1BC3 /* Pods-KinWallet.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KinWallet.release.xcconfig"; path = "Pods/Target Support Files/Pods-KinWallet/Pods-KinWallet.release.xcconfig"; sourceTree = "<group>"; };
 		25246B587FA0565B0EC72751 /* Pods-KinWalletUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KinWalletUITests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-KinWalletUITests/Pods-KinWalletUITests.debug.xcconfig"; sourceTree = "<group>"; };
+		2731820220EF7EA600FCFB8C /* BridgingHeader.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BridgingHeader.h; sourceTree = "<group>"; };
 		3066337B2058FFCE00F9BB45 /* Fabric.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Fabric.framework; sourceTree = "<group>"; };
 		3066337C2058FFCE00F9BB45 /* Crashlytics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Crashlytics.framework; sourceTree = "<group>"; };
 		7B0DD744421168E44BA1A995 /* Pods-KinWalletUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-KinWalletUITests.release.xcconfig"; path = "Pods/Target Support Files/Pods-KinWalletUITests/Pods-KinWalletUITests.release.xcconfig"; sourceTree = "<group>"; };
@@ -1146,6 +1147,7 @@
 				91401375201635990066367C /* UIView+KinWallet.swift */,
 				9140137C201748100066367C /* UIViewController+KinWallet.swift */,
 				91AAB934201E0C920075DAA1 /* String+KinWallet.swift */,
+				2731820220EF7EA600FCFB8C /* BridgingHeader.h */,
 				91796BCE2027578500F8C6A0 /* TimeZone+KinWallet.swift */,
 				91796BC82027276000F8C6A0 /* UIDevice+KinWallet.swift */,
 				91CB636320597F3C00C65404 /* URL+KinWallet.swift */,

--- a/KinWallet/Extensions/BridgingHeader.h
+++ b/KinWallet/Extensions/BridgingHeader.h
@@ -1,0 +1,13 @@
+//
+//  BridgingHeader.h
+//  KinWallet
+//
+//  Copyright © 2018 KinFoundation. All rights reserved.
+//
+
+#ifndef BridgingHeader_h
+#define BridgingHeader_h
+
+#import <CommonCrypto/CommonHMAC.h>
+
+#endif /* BridgingHeader_h */

--- a/KinWallet/Extensions/String+KinWallet.swift
+++ b/KinWallet/Extensions/String+KinWallet.swift
@@ -12,6 +12,18 @@ extension String {
 
         return self.addingPercentEncoding(withAllowedCharacters: allowedQueryParamAndKey)
     }
+    
+    var sha256:String? {
+        guard let stringData = self.data(using: String.Encoding.utf8) else { return nil }
+        return digest(input: stringData as NSData).base64EncodedString(options: [])
+    }
+    
+    private func digest(input : NSData) -> NSData {
+        let digestLength = Int(CC_SHA256_DIGEST_LENGTH)
+        var hash = [UInt8](repeating: 0, count: digestLength)
+        CC_SHA256(input.bytes, UInt32(input.length), &hash)
+        return NSData(bytes: hash, length: digestLength)
+    }
 }
 
 extension UnicodeScalar {
@@ -37,3 +49,4 @@ extension UnicodeScalar {
         return value == 8205
     }
 }
+

--- a/KinWallet/View Controllers and Co./Spend/SendKinOfferActionViewController.swift
+++ b/KinWallet/View Controllers and Co./Spend/SendKinOfferActionViewController.swift
@@ -64,7 +64,7 @@ extension SendKinOfferActionViewController: CNContactPickerDelegate {
         activityIndicatorView.startAnimating()
         sendKinButton.setTitle(nil, for: .normal)
 
-        WebRequests.searchPhoneNumber(phoneNumber).withCompletion { [weak self] address, _ in
+        WebRequests.searchPhoneNumber(phoneNumber.sha256()).withCompletion { [weak self] address, _ in
             DispatchQueue.main.async {
                 guard let `self` = self else {
                     return

--- a/KinWallet/View Controllers and Co./Welcome and Phone Verification/PhoneConfirmationViewController.swift
+++ b/KinWallet/View Controllers and Co./Welcome and Phone Verification/PhoneConfirmationViewController.swift
@@ -133,7 +133,7 @@ class PhoneConfirmationViewController: UIViewController {
     }
 
     func updateServer(with token: String) {
-        WebRequests.updateUserIdToken(token, phoneNumber: phoneNumber).withCompletion { [weak self] success, _ in
+        WebRequests.updateUserIdToken(token, phoneNumber: phoneNumber.sha256()).withCompletion { [weak self] success, _ in
             guard let aSelf = self else {
                 return
             }


### PR DESCRIPTION
Ensured contact phone number won't be stored in the clear on the server end, by applying a basic and straightforward SHA256 hash. Used after verification as well as locating other users to send Kin to.

Yes, phone number can be brute forced fairly easily, but this is just a belts and braces approach so phone numbers cannot easily be extracted by looking at the DB.

A similar fix would need to be put into the Android version with the same hash function/outcome.

Can't build or test locally due to config files missing.