### PR TITLE
When keystore is absent, delete all data and start from scratch

### DIFF
--- a/KinWallet/Helpers/Kin.swift
+++ b/KinWallet/Helpers/Kin.swift
@@ -65,6 +65,8 @@ class Kin {
 // MARK: Account cleanup
 extension Kin {
     func resetKeyStore() {
+        UserDefaults.standard.set(AccountStatus.notCreated.rawValue,
+                                  forKey: accountStatusUserDefaultsKey)
         client.deleteKeystore()
         self.account = try! client.addAccount()
     }

--- a/KinWallet/Helpers/KinLoader.swift
+++ b/KinWallet/Helpers/KinLoader.swift
@@ -6,7 +6,7 @@
 import Foundation
 import KinUtil
 
-private let nextTaskIdentifier = "Kinit-NextTask"
+let nextTaskIdentifier = "Kinit-NextTask"
 
 enum FetchResult<T> {
     case none(Error?)

--- a/KinWallet/Model/User.swift
+++ b/KinWallet/Model/User.swift
@@ -83,6 +83,11 @@ extension User {
         User._current = self
         SimpleDatastore.persist(self, with: User.CurrentUserStorageIdentifier)
     }
+
+    static func reset() {
+        User._current = nil
+        SimpleDatastore.delete(objectOf: User.self, with: CurrentUserStorageIdentifier)
+    }
 }
 
 extension User {

--- a/KinWallet/View Controllers and Co./MoreViewController.swift
+++ b/KinWallet/View Controllers and Co./MoreViewController.swift
@@ -37,9 +37,13 @@ class MoreViewController: UIViewController {
         super.viewDidLoad()
 
         let fourTapGesture = UITapGestureRecognizer(target: self, action: #selector(tapGestureRecognized))
-
         fourTapGesture.numberOfTapsRequired = 4
+
+        #if DEBUG
+        fourTapGesture.numberOfTouchesRequired = 2
+        #else
         fourTapGesture.numberOfTouchesRequired = 4
+        #endif
 
         view.addGestureRecognizer(fourTapGesture)
     }


### PR DESCRIPTION
In some cases, when the user makes a backup in iTunes without password (and encryption), the keychain is not recovered, and therefore, the keystore is lost.

At every launch, we will check if the address stored in the current user matches the address given by Kin.shared. If they don't match, we currently delete all data and start like a clean install: Delete user, the cached next task, and task results.